### PR TITLE
Fix typo in one of the header files

### DIFF
--- a/src/diag_sinter_density.h
+++ b/src/diag_sinter_density.h
@@ -1,4 +1,4 @@
-di/* ----------------------------------------------------------------------
+/* ----------------------------------------------------------------------
    SPPARKS - Stochastic Parallel PARticle Kinetic Simulator
    http://www.cs.sandia.gov/~sjplimp/spparks.html
    Steve Plimpton, sjplimp@sandia.gov, Sandia National Laboratories


### PR DESCRIPTION
Some stray characters crept into the diag_sinter_density.h file - this PR removes them