### PR TITLE
Avoid a compiler warning

### DIFF
--- a/src/app_lattice.cpp
+++ b/src/app_lattice.cpp
@@ -764,6 +764,7 @@ int AppLattice::whichset(int m)
 {
   for (int iset = 0; iset < nset; iset++)
     if (set[iset].i2site[m] >= 0) return iset;
+  return -1;    // should never reach this line
 }
 
 /* ---------------------------------------------------------------------- */


### PR DESCRIPTION
Add a dummy return to a new function in AppLattice, to avoid a compiler warning.