### PR TITLE
Fix 2 bugs with off-lattice models

### DIFF
--- a/src/MAKE/Makefile.mpi_debug
+++ b/src/MAKE/Makefile.mpi_debug
@@ -1,4 +1,4 @@
-# serial_debug = RedHat Linux box, g++, no MPI, -g enabled
+# mpi_debug = MPI with its default compiler and -g enabled
 
 SHELL = /bin/sh
 
@@ -6,12 +6,12 @@ SHELL = /bin/sh
 # compiler/linker settings
 # specify flags and libraries needed for your compiler
 
-CC =		g++
+CC =		mpicxx
 CCFLAGS =	-g -O -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
-LINK =		g++
+LINK =		mpicxx
 LINKFLAGS =	-g -O
 LIB =	  	
 SIZE =		size
@@ -27,15 +27,16 @@ SHLIBFLAGS =	-shared
 # SPPARKS ifdef options, see doc/Section_start.html
 
 SPK_INC =	-DSPPARKS_GZIP
+SPK_INC =	-DSPPARKS_GZIP -DSPPARKS_UNORDERED_MAP
 
 # MPI library, can be src/STUBS dummy lib
 # INC = path for mpi.h, MPI compiler settings
 # PATH = path for MPI library
 # LIB = name of MPI library
 
-MPI_INC =       -I../STUBS
-MPI_PATH = 	
-MPI_LIB =	../STUBS/libmpi.a
+MPI_INC =
+MPI_PATH =
+MPI_LIB =
 
 # JPEG library, only needed if -DLAMMPS_JPEG listed with LMP_INC
 # INC = path for jpeglib.h
@@ -44,15 +45,20 @@ MPI_LIB =	../STUBS/libmpi.a
 
 JPG_INC =       
 JPG_PATH = 	
-JPG_LIB =	/usr/local/lib/libjpeg.a
+JPG_LIB =       
 
 # ---------------------------------------------------------------------
 # build rules and dependencies
 # no need to edit this section
 
-EXTRA_INC = $(SPK_INC) $(MPI_INC) $(JPG_INC)
-EXTRA_PATH = $(MPI_PATH) $(JPG_PATH)
-EXTRA_LIB = $(MPI_LIB) $(JPG_LIB)
+include	Makefile.package.settings
+include	Makefile.package
+
+EXTRA_INC = $(SPK_INC) $(PKG_INC) $(MPI_INC) $(JPG_INC) $(PKG_SYSINC)
+EXTRA_PATH = $(PKG_PATH) $(MPI_PATH) $(JPG_PATH) $(PKG_SYSPATH)
+EXTRA_LIB = $(PKG_LIB) $(MPI_LIB) $(JPG_LIB) $(PKG_SYSLIB)
+EXTRA_CPP_DEPENDS = $(PKG_CPP_DEPENDS)
+EXTRA_LINK_DEPENDS = $(PKG_LINK_DEPENDS)
 
 # Path to src files
 
@@ -84,5 +90,10 @@ shlib:	$(OBJ)
 
 # Individual dependencies
 
-DEPENDS = $(OBJ:.o=.d)
-include $(DEPENDS)
+depend : fastdep.exe $(SRC)
+	@./fastdep.exe $(EXTRA_INC) -- $^ > .depend || exit 1
+
+fastdep.exe: ../DEPEND/fastdep.c
+	cc -O -o $@ $<
+
+sinclude .depend

--- a/src/app_off_lattice.h
+++ b/src/app_off_lattice.h
@@ -82,7 +82,8 @@ class AppOffLattice : public App {
   int sectorflag;              // 1 if partition my domain into sectors
   int nsector;                 // 1,2,4,8 = # of sectors
   int nsector_user;            // 0 if default, else 2,4,8
-
+  int maxlocal;                // max size of in_sector and site2i
+  
   double Ladapt;               // adaptive sector time increments for KMC
   double tstop;                // requested time increment in sector
   double nstop;                // requested events per site in sector

--- a/src/create_sites.cpp
+++ b/src/create_sites.cpp
@@ -416,9 +416,9 @@ void CreateSites::structured_lattice()
       error->all(FLERR,"Did not create correct number of sites");
   }
 
-  // for simple latice, do further checking and store extents in AppLattice
+  // for simple lattice, do further checking and store extents in AppLattice
 
-  if (simple) {
+  if (simple && latticeflag) {
 
     // convert SPPARKS loop bounds to Stitch integer indices
 
@@ -487,6 +487,10 @@ void CreateSites::structured_lattice()
     applattice->zlo_me_simple = zlo_me;
     applattice->zhi_me_simple = zhi_me;
   }
+
+  // if offlatice, free siteijk b/c structured_connectivity() will not be called
+
+  if (latticeflag == 0) memory->destroy(siteijk);
 }
 
 /* ----------------------------------------------------------------------


### PR DESCRIPTION
These issues were reported by Qing Shi (McGill U).

(1) The create_sites command had logic only relevant to on-lattice models, which was also being invoked for off-lattice models

(2) One of the rejection solvers for off-lattice models was not accounting for the face that particle/sector counts could grow due to particles migrating due to communication interleaved with sector solves.

Both issues should be fixed by this PR.

A new makefile for MPI with debugging was also added.  And a memory leak was fixed for off-lattice models.

Steve
