### PR TITLE
Update version to 6 Sep 2023 in preparation for release

### DIFF
--- a/doc/Manual.html
+++ b/doc/Manual.html
@@ -1,14 +1,14 @@
 <HTML>
 <HEAD>
 <TITLE>SPPARKS Users Manual</TITLE>
-<META NAME="docnumber" CONTENT="06 Sep 2023 version">
-<META NAME="author" CONTENT="http://spparks.sandia.gov - Sandia National Laboratories">
+<META NAME="docnumber" CONTENT="6 Sep 2023 version">
+<META NAME="author" CONTENT="https://spparks.github.io - Sandia National Laboratories">
 <META NAME="copyright" CONTENT="Copyright (2008) Sandia Corporation.  This software and manual is distributed under the GNU General Public License.">
 </HEAD>
 
 <BODY>
 
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 
@@ -22,13 +22,13 @@
 
 <CENTER><H3>SPPARKS Documentation 
 </H3></CENTER>
-<CENTER><H4>06 Sep 2023 version 
+<CENTER><H4>6 Sep 2023 version 
 </H4></CENTER>
 <H4>Version info: 
 </H4>
 <P>The SPPARKS "version" is the date when it was released, such as 12 Jun
 2018. SPPARKS is updated continuously.  Whenever we fix a bug or add a
-feature, we release it immediately, and post a notice on <A HREF = "http://www.cs.sandia.gov/spparks/bug.html">this page of
+feature, we release it immediately, and post a notice on <A HREF = "https://spparks.github.io/bug.html">this page of
 the WWW site</A>.  Each dated copy of SPPARKS contains all the
 features and bug-fixes up to and including that version date. The
 version date is printed to the screen and logfile every time you run
@@ -51,11 +51,13 @@ open-source code, distributed freely under the terms of the GNU Public
 License (GPL), or sometimes by request under the terms of the GNU
 Lesser General Public License (LGPL).
 </P>
-<P>The developers of SPPARKS are <A HREF = "http://www.cs.sandia.gov/~sjplimp">Steve Plimpton</A>, Aidan Thompson,
-and Alex Slepoy.  They can be contacted at sjplimp@sandia.gov,
-athomps@sandia.gov, and alexander.slepoy@nnsa.doe.gov.  The <A HREF = "http://spparks.sandia.gov">SPPARKS
-WWW Site</A> at http://spparks.sandia.gov has more information about
-the code and its uses.
+<P>The <A HREF = "https://spparks.github.io">SPPARKS website</A> has more information about the code and
+publications that desribe it.  The current SPPARKS developers are John
+Mitchell (Sandia National Labs) and <A HREF = "https://sjplimp.github.io">Steve Plimpton</A>.  They can be
+contacted at jamitch@sandia.gov and sjplimp@gmail.com respectively.
+Past developers and other significant code contributores are listed on
+the <A HREF = "https://spparks.github.io/authors.html">Authors page</A> of the
+website.
 </P>
 
 

--- a/doc/Manual.html
+++ b/doc/Manual.html
@@ -1,7 +1,7 @@
 <HTML>
 <HEAD>
 <TITLE>SPPARKS Users Manual</TITLE>
-<META NAME="docnumber" CONTENT="16 Jan 2023 version">
+<META NAME="docnumber" CONTENT="06 Sep 2023 version">
 <META NAME="author" CONTENT="http://spparks.sandia.gov - Sandia National Laboratories">
 <META NAME="copyright" CONTENT="Copyright (2008) Sandia Corporation.  This software and manual is distributed under the GNU General Public License.">
 </HEAD>
@@ -22,7 +22,7 @@
 
 <CENTER><H3>SPPARKS Documentation 
 </H3></CENTER>
-<CENTER><H4>16 Jan 2023 version 
+<CENTER><H4>06 Sep 2023 version 
 </H4></CENTER>
 <H4>Version info: 
 </H4>

--- a/doc/Manual.html
+++ b/doc/Manual.html
@@ -8,7 +8,7 @@
 
 <BODY>
 
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/Manual.txt
+++ b/doc/Manual.txt
@@ -7,7 +7,7 @@
 
 <BODY>
 
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/Manual.txt
+++ b/doc/Manual.txt
@@ -1,6 +1,6 @@
 <HEAD>
 <TITLE>SPPARKS Users Manual</TITLE>
-<META NAME="docnumber" CONTENT="06 Sep 2023 version">
+<META NAME="docnumber" CONTENT="6 Sep 2023 version">
 <META NAME="author" CONTENT="http://spparks.sandia.gov - Sandia National Laboratories">
 <META NAME="copyright" CONTENT="Copyright (2008) Sandia Corporation.  This software and manual is distributed under the GNU General Public License.">
 </HEAD>
@@ -9,7 +9,7 @@
 
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 
@@ -18,7 +18,7 @@
 <H1></H1>
 
 SPPARKS Documentation :c,h3
-06 Sep 2023 version :c,h4
+6 Sep 2023 version :c,h4
 
 Version info: :h4
 
@@ -47,14 +47,16 @@ open-source code, distributed freely under the terms of the GNU Public
 License (GPL), or sometimes by request under the terms of the GNU
 Lesser General Public License (LGPL).
 
-The developers of SPPARKS are "Steve Plimpton"_sjp, Aidan Thompson,
-and Alex Slepoy.  They can be contacted at sjplimp@sandia.gov,
-athomps@sandia.gov, and alexander.slepoy@nnsa.doe.gov.  The "SPPARKS
-WWW Site"_sws at http://spparks.sandia.gov has more information about
-the code and its uses.
+The "SPPARKS website"_sws has more information about the code and
+publications that desribe it.  The current SPPARKS developers are John
+Mitchell (Sandia National Labs) and "Steve Plimpton"_sjp.  They can be
+contacted at jamitch@sandia.gov and sjplimp@gmail.com respectively.
+Past developers and other significant code contributores are listed on
+the "Authors page"_https://spparks.github.io/authors.html of the
+website.
 
-:link(bug,http://www.cs.sandia.gov/spparks/bug.html)
-:link(sjp,http://www.cs.sandia.gov/~sjplimp)
+:link(bug,https://spparks.github.io/bug.html)
+:link(sjp,https://sjplimp.github.io)
 
 :line
 

--- a/doc/Manual.txt
+++ b/doc/Manual.txt
@@ -1,6 +1,6 @@
 <HEAD>
 <TITLE>SPPARKS Users Manual</TITLE>
-<META NAME="docnumber" CONTENT="16 Jan 2023 version">
+<META NAME="docnumber" CONTENT="06 Sep 2023 version">
 <META NAME="author" CONTENT="http://spparks.sandia.gov - Sandia National Laboratories">
 <META NAME="copyright" CONTENT="Copyright (2008) Sandia Corporation.  This software and manual is distributed under the GNU General Public License.">
 </HEAD>
@@ -18,7 +18,7 @@
 <H1></H1>
 
 SPPARKS Documentation :c,h3
-16 Jan 2023 version :c,h4
+06 Sep 2023 version :c,h4
 
 Version info: :h4
 

--- a/doc/Manual.txt
+++ b/doc/Manual.txt
@@ -1,7 +1,7 @@
 <HEAD>
 <TITLE>SPPARKS Users Manual</TITLE>
 <META NAME="docnumber" CONTENT="6 Sep 2023 version">
-<META NAME="author" CONTENT="http://spparks.sandia.gov - Sandia National Laboratories">
+<META NAME="author" CONTENT="https://spparks.github.io - Sandia National Laboratories">
 <META NAME="copyright" CONTENT="Copyright (2008) Sandia Corporation.  This software and manual is distributed under the GNU General Public License.">
 </HEAD>
 

--- a/doc/Section_commands.html
+++ b/doc/Section_commands.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Section_start.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> -
+<CENTER><A HREF = "Section_start.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS Website</A> -
 <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_howto.html">Next
 Section</A> 
 </CENTER>
@@ -123,7 +123,7 @@ comment or substituted for as a variable.
 script.  The "examples" directory in the SPPARKS distribution contains
 sample input scripts; the corresponding problems are discussed in
 <A HREF = "Section_example.html">this section</A>, and some are animated on the
-<A HREF = "https://spparks.github.io">SPPARKS WWW Site</A>.
+<A HREF = "https://spparks.github.io">SPPARKS website</A>.
 </P>
 <P>A SPPARKS input script typically has 3 parts:
 </P>

--- a/doc/Section_commands.html
+++ b/doc/Section_commands.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Section_start.html">Previous Section</A> - <A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> -
+<CENTER><A HREF = "Section_start.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> -
 <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_howto.html">Next
 Section</A> 
 </CENTER>
@@ -123,7 +123,7 @@ comment or substituted for as a variable.
 script.  The "examples" directory in the SPPARKS distribution contains
 sample input scripts; the corresponding problems are discussed in
 <A HREF = "Section_example.html">this section</A>, and some are animated on the
-<A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A>.
+<A HREF = "https://spparks.github.io">SPPARKS WWW Site</A>.
 </P>
 <P>A SPPARKS input script typically has 3 parts:
 </P>

--- a/doc/Section_commands.txt
+++ b/doc/Section_commands.txt
@@ -1,4 +1,4 @@
-"Previous Section"_Section_start.html - "SPPARKS WWW Site"_sws -
+"Previous Section"_Section_start.html - "SPPARKS Website"_sws -
 "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc - "Next
 Section"_Section_howto.html :c
 
@@ -120,7 +120,7 @@ This section describes the structure of a typical SPPARKS input
 script.  The "examples" directory in the SPPARKS distribution contains
 sample input scripts; the corresponding problems are discussed in
 "this section"_Section_example.html, and some are animated on the
-"SPPARKS WWW Site"_sws.
+"SPPARKS website"_sws.
 
 A SPPARKS input script typically has 3 parts:
 

--- a/doc/Section_commands.txt
+++ b/doc/Section_commands.txt
@@ -2,7 +2,7 @@
 "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc - "Next
 Section"_Section_howto.html :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/Section_errors.html
+++ b/doc/Section_errors.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Section_modify.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> -
+<CENTER><A HREF = "Section_modify.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS Website</A> -
 <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_future.html">Next
 Section</A> 
 </CENTER>

--- a/doc/Section_errors.html
+++ b/doc/Section_errors.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Section_modify.html">Previous Section</A> - <A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> -
+<CENTER><A HREF = "Section_modify.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> -
 <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_future.html">Next
 Section</A> 
 </CENTER>
@@ -81,7 +81,7 @@ buffering or boost the sizes of messages that can be buffered.
 <P>If you are confident that you have found a bug in SPPARKS, please send
 an email to the developers.
 </P>
-<P>First, check the "New features and bug fixes" section of the <A HREF = "http://spparks.sandia.gov">SPPARKS
+<P>First, check the "New features and bug fixes" section of the <A HREF = "https://spparks.github.io">SPPARKS
 WWW site</A> to see if the bug has already been reported or fixed.
 </P>
 <P>If not, the most useful thing you can do for us is to isolate the

--- a/doc/Section_errors.txt
+++ b/doc/Section_errors.txt
@@ -2,7 +2,7 @@
 "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc - "Next
 Section"_Section_future.html :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/Section_errors.txt
+++ b/doc/Section_errors.txt
@@ -1,4 +1,4 @@
-"Previous Section"_Section_modify.html - "SPPARKS WWW Site"_sws -
+"Previous Section"_Section_modify.html - "SPPARKS Website"_sws -
 "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc - "Next
 Section"_Section_future.html :c
 

--- a/doc/Section_example.html
+++ b/doc/Section_example.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Section_howto.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> -
+<CENTER><A HREF = "Section_howto.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS Website</A> -
 <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_perf.html">Next
 Section</A> 
 </CENTER>

--- a/doc/Section_example.html
+++ b/doc/Section_example.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Section_howto.html">Previous Section</A> - <A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> -
+<CENTER><A HREF = "Section_howto.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> -
 <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_perf.html">Next
 Section</A> 
 </CENTER>
@@ -27,7 +27,7 @@ log.potts.foo.P means it ran on P processors of machine "foo".
 animated using the various visuzlization tools, such as the Pizza.py
 toolkit referenced in the <A HREF = "Section_tools.html">Additional Tools</A>
 section of the SPPARKS documentation.  Animations of some of these
-examples can be viewed on the Movies section of the <A HREF = "http://spparks.sandia.gov">SPPARKS WWW
+examples can be viewed on the Movies section of the <A HREF = "https://spparks.github.io">SPPARKS WWW
 Site</A>.
 </P>
 <P>These are the sample problems in the examples sub-directories:

--- a/doc/Section_example.txt
+++ b/doc/Section_example.txt
@@ -1,4 +1,4 @@
-"Previous Section"_Section_howto.html - "SPPARKS WWW Site"_sws -
+"Previous Section"_Section_howto.html - "SPPARKS Website"_sws -
 "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc - "Next
 Section"_Section_perf.html :c
 

--- a/doc/Section_example.txt
+++ b/doc/Section_example.txt
@@ -2,7 +2,7 @@
 "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc - "Next
 Section"_Section_perf.html :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/Section_future.html
+++ b/doc/Section_future.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Section_errors.html">Previous Section</A> - <A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> -
+<CENTER><A HREF = "Section_errors.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> -
 <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Manual.html">Next
 Section</A> 
 </CENTER>

--- a/doc/Section_future.html
+++ b/doc/Section_future.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Section_errors.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> -
+<CENTER><A HREF = "Section_errors.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS Website</A> -
 <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Manual.html">Next
 Section</A> 
 </CENTER>

--- a/doc/Section_future.txt
+++ b/doc/Section_future.txt
@@ -2,7 +2,7 @@
 "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc - "Next
 Section"_Manual.html :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/Section_future.txt
+++ b/doc/Section_future.txt
@@ -1,4 +1,4 @@
-"Previous Section"_Section_errors.html - "SPPARKS WWW Site"_sws -
+"Previous Section"_Section_errors.html - "SPPARKS Website"_sws -
 "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc - "Next
 Section"_Manual.html :c
 

--- a/doc/Section_howto.html
+++ b/doc/Section_howto.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Section_commands.html">Previous Section</A> - <A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> -
+<CENTER><A HREF = "Section_commands.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> -
 <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_example.html">Next
 Section</A> 
 </CENTER>

--- a/doc/Section_howto.html
+++ b/doc/Section_howto.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Section_commands.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> -
+<CENTER><A HREF = "Section_commands.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS Website</A> -
 <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_example.html">Next
 Section</A> 
 </CENTER>

--- a/doc/Section_howto.txt
+++ b/doc/Section_howto.txt
@@ -1,4 +1,4 @@
-"Previous Section"_Section_commands.html - "SPPARKS WWW Site"_sws -
+"Previous Section"_Section_commands.html - "SPPARKS Website"_sws -
 "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc - "Next
 Section"_Section_example.html :c
 

--- a/doc/Section_howto.txt
+++ b/doc/Section_howto.txt
@@ -2,7 +2,7 @@
 "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc - "Next
 Section"_Section_example.html :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/Section_intro.html
+++ b/doc/Section_intro.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Manual.html">Previous Section</A> - <A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS
+<CENTER><A HREF = "Manual.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS
 Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_start.html">Next
 Section</A> 
 </CENTER>
@@ -84,7 +84,7 @@ distributed- or shared-memory machines.
 </P>
 
 
-<P>SPPARKS is a freely-available open-source code.  See the <A HREF = "http://spparks.sandia.gov">SPPARKS WWW
+<P>SPPARKS is a freely-available open-source code.  See the <A HREF = "https://spparks.github.io">SPPARKS WWW
 Site</A> for download information.  It is distributed under the terms
 of the <A HREF = "http://www.gnu.org/copyleft/gpl.html">GNU Public License (GPL)</A>, or sometimes by request under
 the terms of the <A HREF = "http://www.gnu.org/licenses/lgpl-2.1.html">GNU Lesser General Public License (LGPL)</A>,

--- a/doc/Section_intro.html
+++ b/doc/Section_intro.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Manual.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS
+<CENTER><A HREF = "Manual.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS
 Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_start.html">Next
 Section</A> 
 </CENTER>

--- a/doc/Section_intro.txt
+++ b/doc/Section_intro.txt
@@ -2,7 +2,7 @@
 Documentation"_sd - "SPPARKS Commands"_sc - "Next
 Section"_Section_start.html :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/Section_intro.txt
+++ b/doc/Section_intro.txt
@@ -1,4 +1,4 @@
-"Previous Section"_Manual.html - "SPPARKS WWW Site"_sws - "SPPARKS
+"Previous Section"_Manual.html - "SPPARKS Website"_sws - "SPPARKS
 Documentation"_sd - "SPPARKS Commands"_sc - "Next
 Section"_Section_start.html :c
 

--- a/doc/Section_modify.html
+++ b/doc/Section_modify.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Section_tools.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> -
+<CENTER><A HREF = "Section_tools.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS Website</A> -
 <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_errors.html">Next
 Section</A> 
 </CENTER>

--- a/doc/Section_modify.html
+++ b/doc/Section_modify.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Section_tools.html">Previous Section</A> - <A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> -
+<CENTER><A HREF = "Section_tools.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> -
 <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_errors.html">Next
 Section</A> 
 </CENTER>

--- a/doc/Section_modify.txt
+++ b/doc/Section_modify.txt
@@ -2,7 +2,7 @@
 "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc - "Next
 Section"_Section_errors.html :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/Section_modify.txt
+++ b/doc/Section_modify.txt
@@ -1,4 +1,4 @@
-"Previous Section"_Section_tools.html - "SPPARKS WWW Site"_sws -
+"Previous Section"_Section_tools.html - "SPPARKS Website"_sws -
 "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc - "Next
 Section"_Section_errors.html :c
 

--- a/doc/Section_perf.html
+++ b/doc/Section_perf.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Section_example.html">Previous Section</A> - <A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> -
+<CENTER><A HREF = "Section_example.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> -
 <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_tools.html">Next
 Section</A> 
 </CENTER>

--- a/doc/Section_perf.html
+++ b/doc/Section_perf.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Section_example.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> -
+<CENTER><A HREF = "Section_example.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS Website</A> -
 <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_tools.html">Next
 Section</A> 
 </CENTER>

--- a/doc/Section_perf.txt
+++ b/doc/Section_perf.txt
@@ -1,4 +1,4 @@
-"Previous Section"_Section_example.html - "SPPARKS WWW Site"_sws -
+"Previous Section"_Section_example.html - "SPPARKS Website"_sws -
 "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc - "Next
 Section"_Section_tools.html :c
 

--- a/doc/Section_perf.txt
+++ b/doc/Section_perf.txt
@@ -2,7 +2,7 @@
 "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc - "Next
 Section"_Section_tools.html :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/Section_python.html
+++ b/doc/Section_python.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Section_modify.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_errors.html">Next Section</A> 
+<CENTER><A HREF = "Section_modify.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_errors.html">Next Section</A> 
 </CENTER>
 
 

--- a/doc/Section_python.html
+++ b/doc/Section_python.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Section_modify.html">Previous Section</A> - <A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_errors.html">Next Section</A> 
+<CENTER><A HREF = "Section_modify.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_errors.html">Next Section</A> 
 </CENTER>
 
 

--- a/doc/Section_python.txt
+++ b/doc/Section_python.txt
@@ -1,6 +1,6 @@
 "Previous Section"_Section_modify.html - "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc - "Next Section"_Section_errors.html :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/Section_python.txt
+++ b/doc/Section_python.txt
@@ -1,4 +1,4 @@
-"Previous Section"_Section_modify.html - "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc - "Next Section"_Section_errors.html :c
+"Previous Section"_Section_modify.html - "SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc - "Next Section"_Section_errors.html :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/Section_start.html
+++ b/doc/Section_start.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Section_intro.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> -
+<CENTER><A HREF = "Section_intro.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS Website</A> -
 <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_commands.html">Next
 Section</A> 
 </CENTER>

--- a/doc/Section_start.html
+++ b/doc/Section_start.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Section_intro.html">Previous Section</A> - <A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> -
+<CENTER><A HREF = "Section_intro.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> -
 <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_commands.html">Next
 Section</A> 
 </CENTER>

--- a/doc/Section_start.txt
+++ b/doc/Section_start.txt
@@ -2,7 +2,7 @@
 "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc - "Next
 Section"_Section_commands.html :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/Section_start.txt
+++ b/doc/Section_start.txt
@@ -1,4 +1,4 @@
-"Previous Section"_Section_intro.html - "SPPARKS WWW Site"_sws -
+"Previous Section"_Section_intro.html - "SPPARKS Website"_sws -
 "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc - "Next
 Section"_Section_commands.html :c
 

--- a/doc/Section_tools.html
+++ b/doc/Section_tools.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Section_perf.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> -
+<CENTER><A HREF = "Section_perf.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS Website</A> -
 <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_modify.html">Next
 Section</A> 
 </CENTER>

--- a/doc/Section_tools.html
+++ b/doc/Section_tools.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "Section_perf.html">Previous Section</A> - <A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> -
+<CENTER><A HREF = "Section_perf.html">Previous Section</A> - <A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> -
 <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> - <A HREF = "Section_modify.html">Next
 Section</A> 
 </CENTER>

--- a/doc/Section_tools.txt
+++ b/doc/Section_tools.txt
@@ -1,4 +1,4 @@
-"Previous Section"_Section_perf.html - "SPPARKS WWW Site"_sws -
+"Previous Section"_Section_perf.html - "SPPARKS Website"_sws -
 "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc - "Next
 Section"_Section_modify.html :c
 

--- a/doc/Section_tools.txt
+++ b/doc/Section_tools.txt
@@ -2,7 +2,7 @@
 "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc - "Next
 Section"_Section_modify.html :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/add_reaction.html
+++ b/doc/add_reaction.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/add_reaction.html
+++ b/doc/add_reaction.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/add_reaction.txt
+++ b/doc/add_reaction.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/add_reaction.txt
+++ b/doc/add_reaction.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/add_species.html
+++ b/doc/add_species.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/add_species.html
+++ b/doc/add_species.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/add_species.txt
+++ b/doc/add_species.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/add_species.txt
+++ b/doc/add_species.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/am_build.html
+++ b/doc/am_build.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/am_build.html
+++ b/doc/am_build.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/am_build.txt
+++ b/doc/am_build.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/am_build.txt
+++ b/doc/am_build.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/am_cartesian_layer.html
+++ b/doc/am_cartesian_layer.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/am_cartesian_layer.html
+++ b/doc/am_cartesian_layer.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/am_cartesian_layer.txt
+++ b/doc/am_cartesian_layer.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/am_cartesian_layer.txt
+++ b/doc/am_cartesian_layer.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/am_pass.html
+++ b/doc/am_pass.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/am_pass.html
+++ b/doc/am_pass.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/am_pass.txt
+++ b/doc/am_pass.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/am_pass.txt
+++ b/doc/am_pass.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/am_path.html
+++ b/doc/am_path.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/am_path.html
+++ b/doc/am_path.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/am_path.txt
+++ b/doc/am_path.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/am_path.txt
+++ b/doc/am_path.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/am_path_layer.html
+++ b/doc/am_path_layer.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/am_path_layer.html
+++ b/doc/am_path_layer.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/am_path_layer.txt
+++ b/doc/am_path_layer.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/am_path_layer.txt
+++ b/doc/am_path_layer.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/am_pathgen.html
+++ b/doc/am_pathgen.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/am_pathgen.html
+++ b/doc/am_pathgen.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/am_pathgen.txt
+++ b/doc/am_pathgen.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/am_pathgen.txt
+++ b/doc/am_pathgen.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/app_am_ellipsoid.html
+++ b/doc/app_am_ellipsoid.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_am_ellipsoid.html
+++ b/doc/app_am_ellipsoid.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_am_ellipsoid.txt
+++ b/doc/app_am_ellipsoid.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_am_ellipsoid.txt
+++ b/doc/app_am_ellipsoid.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/app_chemistry.html
+++ b/doc/app_chemistry.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_chemistry.html
+++ b/doc/app_chemistry.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_chemistry.txt
+++ b/doc/app_chemistry.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_chemistry.txt
+++ b/doc/app_chemistry.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/app_diffusion.html
+++ b/doc/app_diffusion.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_diffusion.html
+++ b/doc/app_diffusion.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_diffusion.txt
+++ b/doc/app_diffusion.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_diffusion.txt
+++ b/doc/app_diffusion.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/app_diffusion_multiphase.html
+++ b/doc/app_diffusion_multiphase.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_diffusion_multiphase.html
+++ b/doc/app_diffusion_multiphase.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_diffusion_multiphase.txt
+++ b/doc/app_diffusion_multiphase.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_diffusion_multiphase.txt
+++ b/doc/app_diffusion_multiphase.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/app_erbium.html
+++ b/doc/app_erbium.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_erbium.html
+++ b/doc/app_erbium.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_erbium.txt
+++ b/doc/app_erbium.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_erbium.txt
+++ b/doc/app_erbium.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/app_ising.html
+++ b/doc/app_ising.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_ising.html
+++ b/doc/app_ising.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_ising.txt
+++ b/doc/app_ising.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_ising.txt
+++ b/doc/app_ising.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/app_membrane.html
+++ b/doc/app_membrane.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_membrane.html
+++ b/doc/app_membrane.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_membrane.txt
+++ b/doc/app_membrane.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_membrane.txt
+++ b/doc/app_membrane.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/app_phasefield_potts.html
+++ b/doc/app_phasefield_potts.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 
@@ -70,7 +70,7 @@ by diffusion. For a full description of the model, see the paper by
 <A HREF = "#Homer">Homer et al.</A>.
 </P>
 <P>See the examples/potts_pfm directory for an example script using this
-command.  See the <A HREF = "http://spparks.sandia.gov/pictures.html">Pictures web
+command.  See the <A HREF = "https://spparks.github.io/pictures.html">Pictures web
 page</A> for images of
 simulations performed with this command.
 </P>

--- a/doc/app_phasefield_potts.html
+++ b/doc/app_phasefield_potts.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_phasefield_potts.txt
+++ b/doc/app_phasefield_potts.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_phasefield_potts.txt
+++ b/doc/app_phasefield_potts.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 
@@ -55,7 +55,7 @@ by diffusion. For a full description of the model, see the paper by
 
 See the examples/potts_pfm directory for an example script using this
 command.  See the "Pictures web
-page"_http://spparks.sandia.gov/pictures.html for images of
+page"_https://spparks.github.io/pictures.html for images of
 simulations performed with this command.
 
 :line

--- a/doc/app_potts.html
+++ b/doc/app_potts.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_potts.html
+++ b/doc/app_potts.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_potts.txt
+++ b/doc/app_potts.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_potts.txt
+++ b/doc/app_potts.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/app_potts_am_bezier.html
+++ b/doc/app_potts_am_bezier.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_potts_am_bezier.html
+++ b/doc/app_potts_am_bezier.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_potts_am_bezier.txt
+++ b/doc/app_potts_am_bezier.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_potts_am_bezier.txt
+++ b/doc/app_potts_am_bezier.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/app_potts_am_path_gen.html
+++ b/doc/app_potts_am_path_gen.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_potts_am_path_gen.html
+++ b/doc/app_potts_am_path_gen.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_potts_am_path_gen.txt
+++ b/doc/app_potts_am_path_gen.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_potts_am_path_gen.txt
+++ b/doc/app_potts_am_path_gen.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/app_potts_am_weld.html
+++ b/doc/app_potts_am_weld.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_potts_am_weld.html
+++ b/doc/app_potts_am_weld.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_potts_am_weld.txt
+++ b/doc/app_potts_am_weld.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_potts_am_weld.txt
+++ b/doc/app_potts_am_weld.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/app_potts_grad.html
+++ b/doc/app_potts_grad.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_potts_grad.html
+++ b/doc/app_potts_grad.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_potts_grad.txt
+++ b/doc/app_potts_grad.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_potts_grad.txt
+++ b/doc/app_potts_grad.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/app_potts_pin.html
+++ b/doc/app_potts_pin.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_potts_pin.html
+++ b/doc/app_potts_pin.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_potts_pin.txt
+++ b/doc/app_potts_pin.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_potts_pin.txt
+++ b/doc/app_potts_pin.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/app_potts_strain.html
+++ b/doc/app_potts_strain.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_potts_strain.html
+++ b/doc/app_potts_strain.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_potts_strain.txt
+++ b/doc/app_potts_strain.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_potts_strain.txt
+++ b/doc/app_potts_strain.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/app_potts_strain_pin.html
+++ b/doc/app_potts_strain_pin.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_potts_strain_pin.html
+++ b/doc/app_potts_strain_pin.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_potts_strain_pin.txt
+++ b/doc/app_potts_strain_pin.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_potts_strain_pin.txt
+++ b/doc/app_potts_strain_pin.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/app_potts_weld.html
+++ b/doc/app_potts_weld.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_potts_weld.html
+++ b/doc/app_potts_weld.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_potts_weld.txt
+++ b/doc/app_potts_weld.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_potts_weld.txt
+++ b/doc/app_potts_weld.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/app_potts_weld_jom.html
+++ b/doc/app_potts_weld_jom.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_potts_weld_jom.html
+++ b/doc/app_potts_weld_jom.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_potts_weld_jom.txt
+++ b/doc/app_potts_weld_jom.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_potts_weld_jom.txt
+++ b/doc/app_potts_weld_jom.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/app_relax.html
+++ b/doc/app_relax.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_relax.html
+++ b/doc/app_relax.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_relax.txt
+++ b/doc/app_relax.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_relax.txt
+++ b/doc/app_relax.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/app_sinter.html
+++ b/doc/app_sinter.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://www.cs.sandia.gov/~sjplimp/spparks.html">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "http://www.cs.sandia.gov/~sjplimp/spparks.html">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_sinter.txt
+++ b/doc/app_sinter.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,http://www.cs.sandia.gov/~sjplimp/spparks.html)
 :link(sd,Manual.html)

--- a/doc/app_sos.html
+++ b/doc/app_sos.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_sos.html
+++ b/doc/app_sos.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_sos.txt
+++ b/doc/app_sos.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_sos.txt
+++ b/doc/app_sos.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/app_style.html
+++ b/doc/app_style.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_style.html
+++ b/doc/app_style.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_style.txt
+++ b/doc/app_style.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_style.txt
+++ b/doc/app_style.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/app_test_group.html
+++ b/doc/app_test_group.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_test_group.html
+++ b/doc/app_test_group.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/app_test_group.txt
+++ b/doc/app_test_group.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/app_test_group.txt
+++ b/doc/app_test_group.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/barrier.html
+++ b/doc/barrier.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/barrier.html
+++ b/doc/barrier.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/barrier.txt
+++ b/doc/barrier.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/barrier.txt
+++ b/doc/barrier.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/boundary.html
+++ b/doc/boundary.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/boundary.html
+++ b/doc/boundary.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/boundary.txt
+++ b/doc/boundary.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/boundary.txt
+++ b/doc/boundary.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/clear.html
+++ b/doc/clear.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/clear.html
+++ b/doc/clear.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/clear.txt
+++ b/doc/clear.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/clear.txt
+++ b/doc/clear.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/count.html
+++ b/doc/count.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/count.html
+++ b/doc/count.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/count.txt
+++ b/doc/count.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/count.txt
+++ b/doc/count.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/create_box.html
+++ b/doc/create_box.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/create_box.html
+++ b/doc/create_box.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/create_box.txt
+++ b/doc/create_box.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/create_box.txt
+++ b/doc/create_box.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/create_sites.html
+++ b/doc/create_sites.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/create_sites.html
+++ b/doc/create_sites.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/create_sites.txt
+++ b/doc/create_sites.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/create_sites.txt
+++ b/doc/create_sites.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/deep_length.html
+++ b/doc/deep_length.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 
@@ -36,5 +36,6 @@
 <P><A HREF = "deep_width.html">deep_width</A>,
 <A HREF = "ellipsoid_depth.html">ellipsoid_depth</A>
 </P>
-<P><B>Default:</B> 1/4 * yhi</P>
+<P><B>Default:</B> 1/4 * yhi
+</P>
 </HTML>

--- a/doc/deep_length.html
+++ b/doc/deep_length.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/deep_length.txt
+++ b/doc/deep_length.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/deep_length.txt
+++ b/doc/deep_length.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/deep_width.html
+++ b/doc/deep_width.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/deep_width.html
+++ b/doc/deep_width.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 
@@ -36,5 +36,6 @@
 <P><A HREF = "deep_length.html">deep_length</A>,
 <A HREF = "ellipsoid_depth.html">ellipsoid_depth</A>
 </P>
-<P><B>Default:</B> 1/3 * xhi</P>
+<P><B>Default:</B> 1/3 * xhi
+</P>
 </HTML>

--- a/doc/deep_width.txt
+++ b/doc/deep_width.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/deep_width.txt
+++ b/doc/deep_width.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/deposition.html
+++ b/doc/deposition.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/deposition.html
+++ b/doc/deposition.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/deposition.txt
+++ b/doc/deposition.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/deposition.txt
+++ b/doc/deposition.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/diag_array.html
+++ b/doc/diag_array.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/diag_array.html
+++ b/doc/diag_array.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/diag_array.txt
+++ b/doc/diag_array.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/diag_array.txt
+++ b/doc/diag_array.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/diag_cluster.html
+++ b/doc/diag_cluster.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/diag_cluster.html
+++ b/doc/diag_cluster.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/diag_cluster.txt
+++ b/doc/diag_cluster.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/diag_cluster.txt
+++ b/doc/diag_cluster.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/diag_diffusion.html
+++ b/doc/diag_diffusion.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/diag_diffusion.html
+++ b/doc/diag_diffusion.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/diag_diffusion.txt
+++ b/doc/diag_diffusion.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/diag_diffusion.txt
+++ b/doc/diag_diffusion.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/diag_energy.html
+++ b/doc/diag_energy.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/diag_energy.html
+++ b/doc/diag_energy.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/diag_energy.txt
+++ b/doc/diag_energy.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/diag_energy.txt
+++ b/doc/diag_energy.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/diag_erbium.html
+++ b/doc/diag_erbium.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/diag_erbium.html
+++ b/doc/diag_erbium.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/diag_erbium.txt
+++ b/doc/diag_erbium.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/diag_erbium.txt
+++ b/doc/diag_erbium.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/diag_propensity.html
+++ b/doc/diag_propensity.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/diag_propensity.html
+++ b/doc/diag_propensity.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/diag_propensity.txt
+++ b/doc/diag_propensity.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/diag_propensity.txt
+++ b/doc/diag_propensity.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/diag_sinter_avg_neck_area.html
+++ b/doc/diag_sinter_avg_neck_area.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://www.cs.sandia.gov/~sjplimp/spparks.html">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "http://www.cs.sandia.gov/~sjplimp/spparks.html">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/diag_sinter_avg_neck_area.txt
+++ b/doc/diag_sinter_avg_neck_area.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,http://www.cs.sandia.gov/~sjplimp/spparks.html)
 :link(sd,Manual.html)

--- a/doc/diag_sinter_density.html
+++ b/doc/diag_sinter_density.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://www.cs.sandia.gov/~sjplimp/spparks.html">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "http://www.cs.sandia.gov/~sjplimp/spparks.html">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/diag_sinter_density.txt
+++ b/doc/diag_sinter_density.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,http://www.cs.sandia.gov/~sjplimp/spparks.html)
 :link(sd,Manual.html)

--- a/doc/diag_sinter_free_energy_pore.html
+++ b/doc/diag_sinter_free_energy_pore.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://www.cs.sandia.gov/~sjplimp/spparks.html">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "http://www.cs.sandia.gov/~sjplimp/spparks.html">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/diag_sinter_free_energy_pore.txt
+++ b/doc/diag_sinter_free_energy_pore.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,http://www.cs.sandia.gov/~sjplimp/spparks.html)
 :link(sd,Manual.html)

--- a/doc/diag_sinter_pore_curvature.html
+++ b/doc/diag_sinter_pore_curvature.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://www.cs.sandia.gov/~sjplimp/spparks.html">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "http://www.cs.sandia.gov/~sjplimp/spparks.html">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/diag_sinter_pore_curvature.txt
+++ b/doc/diag_sinter_pore_curvature.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,http://www.cs.sandia.gov/~sjplimp/spparks.html)
 :link(sd,Manual.html)

--- a/doc/diag_style.html
+++ b/doc/diag_style.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/diag_style.html
+++ b/doc/diag_style.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/diag_style.txt
+++ b/doc/diag_style.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/diag_style.txt
+++ b/doc/diag_style.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/diffusion_multiphase.html
+++ b/doc/diffusion_multiphase.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/diffusion_multiphase.html
+++ b/doc/diffusion_multiphase.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/diffusion_multiphase.txt
+++ b/doc/diffusion_multiphase.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/diffusion_multiphase.txt
+++ b/doc/diffusion_multiphase.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/dimension.html
+++ b/doc/dimension.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/dimension.html
+++ b/doc/dimension.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/dimension.txt
+++ b/doc/dimension.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/dimension.txt
+++ b/doc/dimension.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/dump.html
+++ b/doc/dump.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/dump.html
+++ b/doc/dump.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/dump.txt
+++ b/doc/dump.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/dump.txt
+++ b/doc/dump.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/dump_image.html
+++ b/doc/dump_image.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/dump_image.html
+++ b/doc/dump_image.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/dump_image.txt
+++ b/doc/dump_image.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/dump_image.txt
+++ b/doc/dump_image.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/dump_modify.html
+++ b/doc/dump_modify.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/dump_modify.html
+++ b/doc/dump_modify.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/dump_modify.txt
+++ b/doc/dump_modify.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/dump_modify.txt
+++ b/doc/dump_modify.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/dump_one.html
+++ b/doc/dump_one.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/dump_one.html
+++ b/doc/dump_one.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/dump_one.txt
+++ b/doc/dump_one.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/dump_one.txt
+++ b/doc/dump_one.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/echo.html
+++ b/doc/echo.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/echo.html
+++ b/doc/echo.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/echo.txt
+++ b/doc/echo.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/echo.txt
+++ b/doc/echo.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/ecoord.html
+++ b/doc/ecoord.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/ecoord.html
+++ b/doc/ecoord.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/ecoord.txt
+++ b/doc/ecoord.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/ecoord.txt
+++ b/doc/ecoord.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/ellipsoid_depth.html
+++ b/doc/ellipsoid_depth.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 
@@ -38,5 +38,6 @@
 <P><A HREF = "deep_length.html">deep_length</A>,
 <A HREF = "deep_width.html">deep_width</A>
 </P>
-<P><B>Default:</B> 1/4 * zhi</P>
+<P><B>Default:</B> 1/4 * zhi
+</P>
 </HTML>

--- a/doc/ellipsoid_depth.html
+++ b/doc/ellipsoid_depth.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/ellipsoid_depth.txt
+++ b/doc/ellipsoid_depth.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/ellipsoid_depth.txt
+++ b/doc/ellipsoid_depth.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/event.html
+++ b/doc/event.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/event.html
+++ b/doc/event.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/event.txt
+++ b/doc/event.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/event.txt
+++ b/doc/event.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/event_ratios.html
+++ b/doc/event_ratios.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://www.cs.sandia.gov/~sjplimp/spparks.html">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "http://www.cs.sandia.gov/~sjplimp/spparks.html">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/event_ratios.txt
+++ b/doc/event_ratios.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,http://www.cs.sandia.gov/~sjplimp/spparks.html)
 :link(sd,Manual.html)

--- a/doc/event_temperatures.html
+++ b/doc/event_temperatures.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://www.cs.sandia.gov/~sjplimp/spparks.html">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "http://www.cs.sandia.gov/~sjplimp/spparks.html">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/event_temperatures.txt
+++ b/doc/event_temperatures.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,http://www.cs.sandia.gov/~sjplimp/spparks.html)
 :link(sd,Manual.html)

--- a/doc/if.html
+++ b/doc/if.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/if.html
+++ b/doc/if.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/if.txt
+++ b/doc/if.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/if.txt
+++ b/doc/if.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/include.html
+++ b/doc/include.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/include.html
+++ b/doc/include.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/include.txt
+++ b/doc/include.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/include.txt
+++ b/doc/include.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/inclusion.html
+++ b/doc/inclusion.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/inclusion.html
+++ b/doc/inclusion.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/inclusion.txt
+++ b/doc/inclusion.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/inclusion.txt
+++ b/doc/inclusion.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/jump.html
+++ b/doc/jump.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/jump.html
+++ b/doc/jump.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/jump.txt
+++ b/doc/jump.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/jump.txt
+++ b/doc/jump.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/label.html
+++ b/doc/label.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/label.html
+++ b/doc/label.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/label.txt
+++ b/doc/label.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/label.txt
+++ b/doc/label.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/lattice.html
+++ b/doc/lattice.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/lattice.html
+++ b/doc/lattice.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/lattice.txt
+++ b/doc/lattice.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/lattice.txt
+++ b/doc/lattice.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/log.html
+++ b/doc/log.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/log.html
+++ b/doc/log.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/log.txt
+++ b/doc/log.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/log.txt
+++ b/doc/log.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/next.html
+++ b/doc/next.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/next.html
+++ b/doc/next.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/next.txt
+++ b/doc/next.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/next.txt
+++ b/doc/next.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/pair_coeff.html
+++ b/doc/pair_coeff.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/pair_coeff.html
+++ b/doc/pair_coeff.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/pair_coeff.txt
+++ b/doc/pair_coeff.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/pair_coeff.txt
+++ b/doc/pair_coeff.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/pair_lj.html
+++ b/doc/pair_lj.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/pair_lj.html
+++ b/doc/pair_lj.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/pair_lj.txt
+++ b/doc/pair_lj.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/pair_lj.txt
+++ b/doc/pair_lj.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/pair_style.html
+++ b/doc/pair_style.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/pair_style.html
+++ b/doc/pair_style.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/pair_style.txt
+++ b/doc/pair_style.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/pair_style.txt
+++ b/doc/pair_style.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/pin.html
+++ b/doc/pin.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/pin.html
+++ b/doc/pin.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/pin.txt
+++ b/doc/pin.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/pin.txt
+++ b/doc/pin.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/potts_am_bezier.html
+++ b/doc/potts_am_bezier.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/potts_am_bezier.html
+++ b/doc/potts_am_bezier.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/potts_am_bezier.txt
+++ b/doc/potts_am_bezier.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/potts_am_bezier.txt
+++ b/doc/potts_am_bezier.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/print.html
+++ b/doc/print.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/print.html
+++ b/doc/print.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/print.txt
+++ b/doc/print.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/print.txt
+++ b/doc/print.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/processors.html
+++ b/doc/processors.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/processors.html
+++ b/doc/processors.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/processors.txt
+++ b/doc/processors.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/processors.txt
+++ b/doc/processors.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/pulse.html
+++ b/doc/pulse.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/pulse.html
+++ b/doc/pulse.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/pulse.txt
+++ b/doc/pulse.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/pulse.txt
+++ b/doc/pulse.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/read_sites.html
+++ b/doc/read_sites.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/read_sites.html
+++ b/doc/read_sites.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/read_sites.txt
+++ b/doc/read_sites.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/read_sites.txt
+++ b/doc/read_sites.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/region.html
+++ b/doc/region.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/region.html
+++ b/doc/region.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/region.txt
+++ b/doc/region.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/region.txt
+++ b/doc/region.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/reset_time.html
+++ b/doc/reset_time.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/reset_time.html
+++ b/doc/reset_time.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/reset_time.txt
+++ b/doc/reset_time.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/reset_time.txt
+++ b/doc/reset_time.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/run.html
+++ b/doc/run.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/run.html
+++ b/doc/run.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/run.txt
+++ b/doc/run.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/run.txt
+++ b/doc/run.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/sector.html
+++ b/doc/sector.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/sector.html
+++ b/doc/sector.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/sector.txt
+++ b/doc/sector.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/sector.txt
+++ b/doc/sector.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/seed.html
+++ b/doc/seed.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/seed.html
+++ b/doc/seed.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/seed.txt
+++ b/doc/seed.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/seed.txt
+++ b/doc/seed.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/set.html
+++ b/doc/set.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/set.html
+++ b/doc/set.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/set.txt
+++ b/doc/set.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/set.txt
+++ b/doc/set.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/shell.html
+++ b/doc/shell.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/shell.html
+++ b/doc/shell.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/shell.txt
+++ b/doc/shell.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/shell.txt
+++ b/doc/shell.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/solve_group.html
+++ b/doc/solve_group.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/solve_group.html
+++ b/doc/solve_group.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/solve_group.txt
+++ b/doc/solve_group.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/solve_group.txt
+++ b/doc/solve_group.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/solve_linear.html
+++ b/doc/solve_linear.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/solve_linear.html
+++ b/doc/solve_linear.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/solve_linear.txt
+++ b/doc/solve_linear.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/solve_linear.txt
+++ b/doc/solve_linear.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/solve_style.html
+++ b/doc/solve_style.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/solve_style.html
+++ b/doc/solve_style.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/solve_style.txt
+++ b/doc/solve_style.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/solve_style.txt
+++ b/doc/solve_style.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/solve_tree.html
+++ b/doc/solve_tree.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/solve_tree.html
+++ b/doc/solve_tree.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/solve_tree.txt
+++ b/doc/solve_tree.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/solve_tree.txt
+++ b/doc/solve_tree.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/stats.html
+++ b/doc/stats.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/stats.html
+++ b/doc/stats.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/stats.txt
+++ b/doc/stats.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/stats.txt
+++ b/doc/stats.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/sweep.html
+++ b/doc/sweep.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/sweep.html
+++ b/doc/sweep.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/sweep.txt
+++ b/doc/sweep.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/sweep.txt
+++ b/doc/sweep.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/temperature.html
+++ b/doc/temperature.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/temperature.html
+++ b/doc/temperature.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/temperature.txt
+++ b/doc/temperature.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/temperature.txt
+++ b/doc/temperature.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/time_sinter_start.html
+++ b/doc/time_sinter_start.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://www.cs.sandia.gov/~sjplimp/spparks.html">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "http://www.cs.sandia.gov/~sjplimp/spparks.html">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/time_sinter_start.txt
+++ b/doc/time_sinter_start.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,http://www.cs.sandia.gov/~sjplimp/spparks.html)
 :link(sd,Manual.html)

--- a/doc/undump.html
+++ b/doc/undump.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/undump.html
+++ b/doc/undump.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/undump.txt
+++ b/doc/undump.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/undump.txt
+++ b/doc/undump.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/variable.html
+++ b/doc/variable.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/variable.html
+++ b/doc/variable.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/variable.txt
+++ b/doc/variable.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/variable.txt
+++ b/doc/variable.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/volume.html
+++ b/doc/volume.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/volume.html
+++ b/doc/volume.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/volume.txt
+++ b/doc/volume.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/volume.txt
+++ b/doc/volume.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/weld_shape_ellipse.html
+++ b/doc/weld_shape_ellipse.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/weld_shape_ellipse.html
+++ b/doc/weld_shape_ellipse.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/weld_shape_ellipse.txt
+++ b/doc/weld_shape_ellipse.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/weld_shape_ellipse.txt
+++ b/doc/weld_shape_ellipse.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/doc/weld_shape_teardrop.html
+++ b/doc/weld_shape_teardrop.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "http://spparks.sandia.gov">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/weld_shape_teardrop.html
+++ b/doc/weld_shape_teardrop.html
@@ -1,5 +1,5 @@
 <HTML>
-<CENTER><A HREF = "https://spparks.github.io">SPPARKS WWW Site</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
+<CENTER><A HREF = "https://spparks.github.io">SPPARKS Website</A> - <A HREF = "Manual.html">SPPARKS Documentation</A> - <A HREF = "Section_commands.html#comm">SPPARKS Commands</A> 
 </CENTER>
 
 

--- a/doc/weld_shape_teardrop.txt
+++ b/doc/weld_shape_teardrop.txt
@@ -1,4 +1,4 @@
-"SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
+"SPPARKS Website"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
 :link(sws,https://spparks.github.io)
 :link(sd,Manual.html)

--- a/doc/weld_shape_teardrop.txt
+++ b/doc/weld_shape_teardrop.txt
@@ -1,6 +1,6 @@
 "SPPARKS WWW Site"_sws - "SPPARKS Documentation"_sd - "SPPARKS Commands"_sc :c
 
-:link(sws,http://spparks.sandia.gov)
+:link(sws,https://spparks.github.io)
 :link(sd,Manual.html)
 :link(sc,Section_commands.html#comm)
 

--- a/src/MAKE/Makefile.attaway
+++ b/src/MAKE/Makefile.attaway
@@ -1,8 +1,8 @@
 # attaway - Intel Xeon Gold, mpic++, openmpi
 
 # need to load the following modules:
-# 1) intel/12.1
-# 2) openmpi-intel/1.8
+# 1) module load intel/19
+# 2) module load mkl/19
 
 SHELL = /bin/sh
 
@@ -11,9 +11,9 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 export OMPI_CXX = icc
+C =		mpicc
 CC =		mpic++
-OPTFLAGS =      -xHost -O2 -fp-model fast=2 -no-prec-div -qoverride-limits \
-                -qopt-zmm-usage=high
+OPTFLAGS =      -xHost -O2 -fp-model fast=2 -no-prec-div -qoverride-limits
 CCFLAGS = -std=c++11 -qopenmp -qno-offload -ansi-alias -restrict \
                 -DLMP_INTEL_USELRT -DLMP_USE_MKL_RNG $(OPTFLAGS) \
                 -I$(MKLROOT)/include
@@ -51,17 +51,23 @@ MPI_LIB =
 # PATH = path for JPEG library
 # LIB = name of JPEG library
 
-JPG_INC =       
-JPG_PATH = 	
-JPG_LIB =	#/usr/local/lib/libjpeg.a
+JPG_INC = -I/usr/include
+JPG_PATH = -L/usr/lib64	
+JPG_LIB = -ljpeg
+
 
 # ---------------------------------------------------------------------
 # build rules and dependencies
 # no need to edit this section
 
-EXTRA_INC = $(SPK_INC) $(MPI_INC) $(JPG_INC)
-EXTRA_PATH = $(MPI_PATH) $(JPG_PATH)
-EXTRA_LIB = $(MPI_LIB) $(JPG_LIB)
+include	Makefile.package.settings
+include	Makefile.package
+
+EXTRA_INC = $(SPK_INC) $(PKG_INC) $(MPI_INC) $(JPG_INC) $(PKG_SYSINC)
+EXTRA_PATH = $(PKG_PATH) $(MPI_PATH) $(JPG_PATH) $(PKG_SYSPATH)
+EXTRA_LIB = $(PKG_LIB) $(MPI_LIB) $(JPG_LIB) $(PKG_SYSLIB)
+EXTRA_CPP_DEPENDS = $(PKG_CPP_DEPENDS)
+EXTRA_LINK_DEPENDS = $(PKG_LINK_DEPENDS)
 
 # Path to src files
 
@@ -93,5 +99,10 @@ shlib:	$(OBJ)
 
 # Individual dependencies
 
-DEPENDS = $(OBJ:.o=.d)
-include $(DEPENDS)
+depend : fastdep.exe $(SRC)
+	@./fastdep.exe $(EXTRA_INC) -- $^ > .depend || exit 1
+
+fastdep.exe: ../DEPEND/fastdep.c
+	$(C) -O -o $@ $<
+
+sinclude .depend

--- a/src/MAKE/Makefile.kachemak.gnu
+++ b/src/MAKE/Makefile.kachemak.gnu
@@ -6,7 +6,8 @@ SHELL = /bin/sh
 # compiler/linker settings
 # specify flags and libraries needed for your compiler
 
-CC =		/opt/local/bin/mpicxx
+CC =		${MPI_HOME}/bin/mpicxx
+C =		${MPI_HOME}/bin/mpicc
 CCFLAGS =	-g -O -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
@@ -36,8 +37,8 @@ SPK_INC =	-DSPPARKS_GZIP  -DSPPARKS_JPEG -DSPPARKS_UNORDERED_MAP
 # PATH = path for MPI library
 # LIB = name of MPI library
 
-MPI_INC =       -I/opt/local/include/openmpi-gcc9
-MPI_PATH =      -L/opt/local/lib/openmpi-gcc9
+MPI_INC =       -I${MPI_HOME}/include
+MPI_PATH =      -L${MPI_HOME}/lib
 MPI_LIB =	-lmpi
 MPI_INC = 
 MPI_PATH =
@@ -48,8 +49,8 @@ MPI_LIB =
 # PATH = path for JPEG library
 # LIB = name of JPEG library
 
-JPG_INC = -I/opt/local/include
-JPG_PATH = -L/opt/local/lib
+JPG_INC = -I/usr/local/include
+JPG_PATH = -L/usr/local/lib
 JPG_LIB = -ljpeg
 
 #STITCH_INC = -I/home/jamitch/local/stitch/include

--- a/src/STUBS/mpi.cpp
+++ b/src/STUBS/mpi.cpp
@@ -415,8 +415,8 @@ int MPI_Gather(void *sendbuf, int sendcount, MPI_Datatype sendtype,
 /* copy values from data1 to data2 */
 
 int MPI_Gatherv(void *sendbuf, int sendcount, MPI_Datatype sendtype,
-		    void *recvbuf, int *recvcounts, int *displs,
-		    MPI_Datatype recvtype, int root, MPI_Comm comm)
+                void *recvbuf, int *recvcounts, int *displs,
+                MPI_Datatype recvtype, int root, MPI_Comm comm)
 {
   int n;
   if (sendtype == MPI_INT) n = sendcount*sizeof(int);
@@ -430,3 +430,26 @@ int MPI_Gatherv(void *sendbuf, int sendcount, MPI_Datatype sendtype,
   memcpy(recvbuf,sendbuf,n);
   return 0;
 }
+
+/* ---------------------------------------------------------------------- */
+
+/* copy values from data1 to data2 */
+
+int MPI_Alltoallv(const void *sendbuf, const int *sendcounts,
+                  const int *sdispls, MPI_Datatype sendtype,
+                  void *recvbuf, const int *recvcounts, const int *rdispls,
+                  MPI_Datatype recvtype, MPI_Comm comm)
+{
+  int n;
+  if (sendtype == MPI_INT) n = sendcounts[0]*sizeof(int);
+  else if (sendtype == MPI_FLOAT) n = sendcounts[0]*sizeof(float);
+  else if (sendtype == MPI_DOUBLE) n = sendcounts[0]*sizeof(double);
+  else if (sendtype == MPI_CHAR) n = sendcounts[0]*sizeof(char);
+  else if (sendtype == MPI_BYTE) n = sendcounts[0]*sizeof(char);
+  else if (sendtype == MPI_LONG_LONG) n = sendcounts[0]*sizeof(uint64_t);
+  else if (sendtype == MPI_DOUBLE_INT) n = sendcounts[0]*sizeof(double_int);
+  
+  memcpy(recvbuf,sendbuf,n);
+  return 0;
+}
+

--- a/src/STUBS/mpi.h
+++ b/src/STUBS/mpi.h
@@ -121,6 +121,10 @@ int MPI_Gather(void *sendbuf, int sendcount, MPI_Datatype sendtype,
 int MPI_Gatherv(void *sendbuf, int sendcount, MPI_Datatype sendtype,
 		    void *recvbuf, int *recvcounts, int *displs,
 		    MPI_Datatype recvtype, int root, MPI_Comm comm);
+int MPI_Alltoallv(const void *sendbuf, const int *sendcounts,
+                  const int *sdispls, MPI_Datatype sendtype,
+                  void *recvbuf, const int *recvcounts, const int *rdispls,
+                  MPI_Datatype recvtype, MPI_Comm comm);
 
 #ifdef __cplusplus
 }

--- a/src/version.h
+++ b/src/version.h
@@ -1,1 +1,1 @@
-#define SPPARKS_VERSION "16 Jan 2023"
+#define SPPARKS_VERSION "06 Sep 2023"

--- a/src/version.h
+++ b/src/version.h
@@ -1,1 +1,1 @@
-#define SPPARKS_VERSION "06 Sep 2023"
+#define SPPARKS_VERSION "6 Sep 2023"


### PR DESCRIPTION
Thanks Steve.  Here are list of things we need to do -- I can do some of these.  

- mpi stub out MPIalltoallv 
- Update publications and replace 'no mans land paper' with new 'spparks' paper
- Update txt files to point at spparks.github.io rather than spparks.sandia.gov 
- Update developers (manual.txt, authors.txt) 