### PR TITLE
Make sintering example work with downloaded sites file

### DIFF
--- a/examples/sintering/README
+++ b/examples/sintering/README
@@ -1,12 +1,14 @@
-This sintering examples reads a gzipped data file via
-the read_sites command.  To do this SPPARKS must have been
-built with the -DSPPARKS_GZIP option in the Makefile.
+This sintering example script reads a gzipped data file CuO3.spins
+which is too large (38 MBytes gzipped) to include in the tarball or
+GitHub distribution.
 
-If you did not or cannot do that, you can uncompress the file:
+To run the example you first need to download the CuO3.spins.gz file
+from this link and put it in this directory:
 
-gunzip CuO3.spins.gz
+https://drive.google.com/file/d/1zr-w54BM2KkahbeIKDFRjeYA4O64USmg/view?usp=drive_link
 
-and also swap the commented/uncommented lines for
-the read_sites command in the input script,
-and then run the script using the uncompressed file.
+Then unzip the gzipped file:
 
+% gunzip CuO3.spins.gz
+
+Then you can run the input script.

--- a/examples/sintering/in.sinter
+++ b/examples/sintering/in.sinter
@@ -1,11 +1,17 @@
-# SPPARKS sinter tests on a powder compact 
+# SPPARKS sinter tests on a powder compact representing CuO3
 
 seed		 56789
 
 app_style	 sinter 
 
-#read_sites	 Cu03.spins
-read_sites	 Cu03.spins.gz
+dimension	 3
+lattice		 sc/26n 1.0
+region           box block 0 403 0 403 0 95
+create_box	 box
+create_sites	 box
+
+# see README for into about this file
+read_sites	 CuO3.spins
 
 event_ratios 	 2.0 1.0 10.0
 
@@ -19,7 +25,7 @@ sector		 yes
 diag_style       energy
 
 stats            1.0
-dump             10.0 dumpCu.sinter
+dump             1 sites 10.0 dumpCu.sinter.* id site
 diag_style       cluster delt 1.0 stats no logfreq 10 500.0 filename clusterCu.dat
 
 run              10.0

--- a/examples/sintering/log.sinter.6Nov24.linux.1
+++ b/examples/sintering/log.sinter.6Nov24.linux.1
@@ -1,0 +1,53 @@
+SPPARKS (6 Sep 2023)
+# SPPARKS sinter tests on a powder compact representing CuO3
+
+seed		 56789
+
+app_style	 sinter 
+
+dimension	 3
+lattice		 sc/26n 1.0
+region           box block 0 403 0 403 0 95
+create_box	 box
+Created box = (0 0 0) to (403 403 95)
+  1 by 1 by 1 processor grid
+create_sites	 box
+Creating sites ...
+  15428855 sites
+  15428855 sites have 26 neighbors
+
+# see README for into about this file
+read_sites	 CuO3.spins
+  15428855 values
+
+event_ratios 	 2.0 1.0 10.0
+
+events_temperatures 1.0 1.0 15.0
+
+sweep		 random
+#sweep		 raster mask yes
+#solve_style      tree
+sector		 yes
+
+diag_style       energy
+
+stats            1.0
+dump             1 sites 10.0 dumpCu.sinter.* id site
+diag_style       cluster delt 1.0 stats no logfreq 10 500.0 filename clusterCu.dat
+
+run              10.0
+Setting up run ...
+Running with 32-bit site IDs
+Memory usage per processor = 2060.62 Mbytes
+      Time      Naccept        Nreject    Nsweeps        Vmade        CPU     Energy
+0 0 0 0 0          0 3.37904e+07
+6.5 5372 1.54235e+07 1 0       5.04 3.37864e+07
+13 10837 3.08469e+07 2 0       13.1 3.37822e+07
+Loop time of 13.1065 on 1 procs
+
+Solve time (%) = 1.63757 (12.4943)
+Update time (%) = 0 (0)
+Comm  time (%) = 0 (0)
+Outpt time (%) = 11.4689 (87.5056)
+App   time (%) = 0 (0)
+Other time (%) = 5.335e-06 (4.07051e-05)

--- a/examples/sintering/log.sinter.6Nov24.linux.4
+++ b/examples/sintering/log.sinter.6Nov24.linux.4
@@ -1,0 +1,53 @@
+SPPARKS (6 Sep 2023)
+# SPPARKS sinter tests on a powder compact representing CuO3
+
+seed		 56789
+
+app_style	 sinter 
+
+dimension	 3
+lattice		 sc/26n 1.0
+region           box block 0 403 0 403 0 95
+create_box	 box
+Created box = (0 0 0) to (403 403 95)
+  2 by 2 by 1 processor grid
+create_sites	 box
+Creating sites ...
+  15428855 sites
+  15428855 sites have 26 neighbors
+
+# see README for into about this file
+read_sites	 CuO3.spins
+  15428855 values
+
+event_ratios 	 2.0 1.0 10.0
+
+events_temperatures 1.0 1.0 15.0
+
+sweep		 random
+#sweep		 raster mask yes
+#solve_style      tree
+sector		 yes
+
+diag_style       energy
+
+stats            1.0
+dump             1 sites 10.0 dumpCu.sinter.* id site
+diag_style       cluster delt 1.0 stats no logfreq 10 500.0 filename clusterCu.dat
+
+run              10.0
+Setting up run ...
+Running with 32-bit site IDs
+Memory usage per processor = 542.5 Mbytes
+      Time      Naccept        Nreject    Nsweeps        Vmade        CPU     Energy
+0 0 0 0 0          0 3.37904e+07
+6.5 5468 1.54234e+07 1 0       2.04 3.37864e+07
+13 10973 3.08467e+07 2 0       7.05 3.37824e+07
+Loop time of 7.04597 on 4 procs
+
+Solve time (%) = 0.598808 (8.49859)
+Update time (%) = 0 (0)
+Comm  time (%) = 0.128935 (1.82991)
+Outpt time (%) = 6.3182 (89.6711)
+App   time (%) = 4.203e-06 (5.96511e-05)
+Other time (%) = 2.12507e-05 (0.000301601)


### PR DESCRIPTION
The CuO3.spins file used as input for the examples/sintering input script is too big to include in the distribution.  It has been posted as a Google Drive file.  This PR adds info to the README on how to donwload and unzip the file to use it with the input script.

The input script has also been updated to match current SPPARKS, and 2 log files for running the example have been added.